### PR TITLE
Fixed login identity creation issue

### DIFF
--- a/lib/ui/signin_screen.dart
+++ b/lib/ui/signin_screen.dart
@@ -64,7 +64,11 @@ class SignInScreenState extends State<SignInScreen> {
       await authProvider.login(currentAccount, password);
 
       if (!mounted) return;
-      final idsProvider = Provider.of<Identities>(context, listen: false);
+      final idsProvider = Provider.of<Identities>(context, listen: false)
+
+      // updating the authToken here of the idsProvider with that of the authProvider
+      ..authToken = authProvider.authtoken;
+
       await idsProvider.fetchOwnidenities();
 
       if (!mounted) return;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   shimmer: ^3.0.0
   multi_select_flutter: ^4.1.3
   collection: any
+  logger: ^2.7.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Previously, when logging in, the identity creation page was coming. This was most likely due to the fact that the authToken was not getting propagated once login was happening for the first time. This was resolved before when the back button was pressed and login happened again, which triggered the update logic in `main.dart` and thereby, we were able to move to the home page.

This fix ensures that once the authToken of the `identityProviders` are set once the login happens. 

Do note that this is a temporary fix. A complete overhaul of the application using state management frameworks like Riverpod would be taken into consideration once all the bugs are resolved.