### PR TITLE
Fixed attach image in rooms

### DIFF
--- a/lib/ui/room/message_delegate.dart
+++ b/lib/ui/room/message_delegate.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:retroshare_api_wrapper/retroshare.dart';
@@ -59,6 +61,32 @@ class MessageDelegate extends StatelessWidget {
                   ),
                   child: Html(
                     data: messageContent,
+                    shrinkWrap: true,
+                    extensions: [
+                      TagExtension(
+                        tagsToExtend: {"img"},
+                        builder: (extensionContext) {
+                          final src = extensionContext.attributes['src'];
+                          if (src != null &&
+                              src.contains('base64,')) {
+                            try {
+                              final base64Data = src.split('base64,').last;
+                              return Image.memory(
+                                base64Decode(base64Data.trim()),
+                                fit: BoxFit.contain,
+                                errorBuilder: (context, error, stackTrace) {
+                                  debugPrint('Error building image: $error');
+                                  return const Icon(Icons.broken_image);
+                                },
+                              );
+                            } catch (e) {
+                              debugPrint('Error decoding base64 image: $e');
+                            }
+                          }
+                          return const SizedBox.shrink();
+                        },
+                      ),
+                    ],
                     style: {
                       'body': Style(
                         margin: Margins.zero,
@@ -74,8 +102,8 @@ class MessageDelegate extends StatelessWidget {
                                 .onSecondaryContainer,
                       ),
                       'img': Style(
-                        width: Width.auto(),
-                        height: Height(150),
+                        width: Width(100, Unit.percent),
+                        height: Height.auto(),
                       ),
                     },
                   ),

--- a/lib/ui/room/messages_tab.dart
+++ b/lib/ui/room/messages_tab.dart
@@ -82,6 +82,12 @@ class MessagesTabState extends State<MessagesTab> {
     }
 
     final imageFile = File(imageXFile.path);
+    final chatId = widget.chat.chatId;
+
+    if (chatId == null) {
+      debugPrint('Error: Chat ID is null.');
+      return;
+    }
 
     try {
       final imageBytes = await imageFile.readAsBytes();
@@ -90,13 +96,17 @@ class MessagesTabState extends State<MessagesTab> {
       final mb = kb / 1024;
 
       if (mb < 3) {
-        var text = base64.encode(imageBytes);
-        text = "<img alt='Image' src='data:image/png;base64,$text'/>";
+        final String base64Image = base64.encode(imageBytes);
+        final String extension = imageXFile.path.split('.').last.toLowerCase();
+        final String mimeType =
+            (extension == 'png') ? 'image/png' : 'image/jpeg';
+        final String htmlText =
+            "<img alt='Image' src='data:$mimeType;base64,$base64Image'/>";
 
         if (!mounted) return;
         await Provider.of<RoomChatLobby>(context, listen: false).sendMessage(
-          widget.chat.chatId!,
-          text,
+          chatId,
+          htmlText,
           (widget.isRoom ?? false) ? ChatIdType.type3 : ChatIdType.type2,
         );
       } else {


### PR DESCRIPTION
Changes made for picture attachments:

1. Added Base64 Decoding Support: Imported dart:convert in message_delegate.dart to allow the app to turn the image text back into viewable bytes.

2. Implemented TagExtension: Added a custom TagExtension to the Html widget in message_delegate.dart. This intercepts <img> tags and handles them natively instead of relying on the default HTML renderer.

3. Added Native Image Rendering: Used Flutter's native Image.memory widget within the extension. This provides better performance and reliability for displaying large Base64 strings.

4. Enhanced Base64 Parsing: Created a more robust extraction logic that splits the src attribute at base64, and trims whitespace to ensure the decoder receives clean data.

5. Added Fallback Error Handling: Included an errorBuilder in the image widget that displays a broken_image icon if the text data is corrupted, preventing empty spaces or crashes.

6. Corrected Image Sizing: Updated the CSS-like Style for img tags to use width: Width(100, Unit.percent) and height: Height.auto(), ensuring images are responsive and stay within the chat bubble.

7. Dynamic MIME Type Detection: Updated messages_tab.dart to detect whether the picked image is a .png or .jpg and set the correct data:image/... prefix in the HTML string.

8. Improved Sending Logic: Added a null check for the chatId in messages_tab.dart to prevent errors when attempting to send an image before a chat is fully initialized.

Code by gemini