### PR TITLE
Added dark theme

### DIFF
--- a/lib/common/bottom_bar.dart
+++ b/lib/common/bottom_bar.dart
@@ -20,23 +20,25 @@ class BottomBar extends StatelessWidget {
         maxHeight: maxHeight,
       ),
       child: DecoratedBox(
-        decoration: const BoxDecoration(
+        decoration: BoxDecoration(
           boxShadow: [
             BoxShadow(
-              color: Colors.black12,
+              color: Theme.of(context).brightness == Brightness.light
+                  ? Colors.black12
+                  : Colors.white10,
               blurRadius: 20,
               spreadRadius: 5,
-              offset: Offset(
+              offset: const Offset(
                 0,
                 15,
               ),
             ),
           ],
-          borderRadius: BorderRadius.only(
+          borderRadius: const BorderRadius.only(
             topLeft: Radius.circular(appBarHeight / 3),
             topRight: Radius.circular(appBarHeight / 3),
           ),
-          color: Colors.white,
+          color: Theme.of(context).colorScheme.surface,
         ),
         child: child,
       ),

--- a/lib/common/button.dart
+++ b/lib/common/button.dart
@@ -21,7 +21,7 @@ class Button extends StatelessWidget {
     return GestureDetector(
       onTap: onPressed,
       child: Container(
-        color: Colors.white,
+        color: Theme.of(context).colorScheme.surface,
         height: buttonHeight,
         child: Row(
           children: <Widget>[

--- a/lib/common/drawer.dart
+++ b/lib/common/drawer.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:provider/provider.dart';
@@ -170,6 +171,21 @@ Widget drawerWidget(BuildContext ctx) {
               buildNavList(Icons.language, 'Discover public chats', () {
                 Navigator.pushNamed(ctx, '/discover_chats');
               }),
+              buildNavList(
+                AdaptiveTheme.of(ctx).mode.isDark
+                    ? Icons.light_mode
+                    : Icons.dark_mode,
+                AdaptiveTheme.of(ctx).mode.isDark
+                    ? 'Switch to Light Mode'
+                    : 'Switch to Dark Mode',
+                () {
+                  if (AdaptiveTheme.of(ctx).mode.isDark) {
+                    AdaptiveTheme.of(ctx).setLight();
+                  } else {
+                    AdaptiveTheme.of(ctx).setDark();
+                  }
+                },
+              ),
               buildNavList(Icons.info_rounded, 'About', () {
                 Navigator.pushNamed(ctx, '/about');
               }),
@@ -195,14 +211,17 @@ Widget drawerWidget(BuildContext ctx) {
 
 AppBar appBar(String title, BuildContext context) {
   return AppBar(
-    backgroundColor: Colors.white,
+    backgroundColor: Theme.of(context).colorScheme.surface,
     shadowColor: Colors.transparent,
     title: Text(
       title,
-      style: const TextStyle(color: Colors.black, fontSize: 14.5),
+      style: TextStyle(
+        color: Theme.of(context).colorScheme.onSurface,
+        fontSize: 14.5,
+      ),
     ),
     leading: BackButton(
-      color: Colors.black,
+      color: Theme.of(context).colorScheme.onSurface,
       onPressed: () {
         Navigator.of(context).pop();
       },
@@ -232,7 +251,7 @@ class NotificationIconState extends State<NotificationIcon> {
       children: [
         Icon(
           Icons.notifications,
-          color: Theme.of(context).primaryColor,
+          color: Theme.of(context).colorScheme.primary,
           size: 28,
         ),
         Positioned(

--- a/lib/common/person_delegate.dart
+++ b/lib/common/person_delegate.dart
@@ -143,28 +143,34 @@ class PersonDelegateState extends State<PersonDelegate>
     );
     _curvedAnimation =
         CurvedAnimation(parent: _animationController, curve: Curves.easeOut);
+  }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
     boxShadow = DecorationTween(
       begin: BoxDecoration(
         boxShadow: [
           BoxShadow(
-            color: Colors.white.withOpacity(0),
+            color: Colors.transparent,
             spreadRadius: appBarHeight / 3,
           ),
         ],
         borderRadius: const BorderRadius.all(Radius.circular(appBarHeight / 3)),
-        color: Colors.white.withOpacity(0),
+        color: Colors.transparent,
       ),
-      end: const BoxDecoration(
+      end: BoxDecoration(
         boxShadow: [
           BoxShadow(
-            color: Colors.black12,
+            color: Theme.of(context).brightness == Brightness.light
+                ? Colors.black12
+                : Colors.white10,
             blurRadius: 10,
             spreadRadius: 2,
           ),
         ],
-        borderRadius: BorderRadius.all(Radius.circular(appBarHeight / 3)),
-        color: Colors.white,
+        borderRadius: const BorderRadius.all(Radius.circular(appBarHeight / 3)),
+        color: Theme.of(context).colorScheme.surface,
       ),
     ).animate(_curvedAnimation);
   }

--- a/lib/common/shimmer.dart
+++ b/lib/common/shimmer.dart
@@ -2,194 +2,212 @@ import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
 
 Widget friendLocationShimmer() {
-  return Padding(
-    padding: const EdgeInsets.symmetric(horizontal: 15),
-    child: Shimmer(
-      gradient: const LinearGradient(
-        colors: [
-          Color(0xFFEBEBF4),
-          Color(0xFFF4F4F4),
-          Color(0xFFEBEBF4),
-        ],
-        stops: [
-          0.1,
-          0.3,
-          0.4,
-        ],
-        begin: Alignment(-1, -0.3),
-        end: Alignment(1, 0.3),
-      ),
-      child: ListView.builder(
-        padding: const EdgeInsets.symmetric(vertical: 15),
-        itemBuilder: (_, __) => Container(
-          padding: const EdgeInsets.only(bottom: 8, left: 8, right: 8, top: 8),
-          margin: const EdgeInsets.only(top: 8, bottom: 10, left: 8, right: 8),
-          decoration: BoxDecoration(
-            border: Border.all(color: Colors.white),
-            borderRadius: BorderRadius.circular(14),
-          ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const SizedBox(
-                height: 10,
-              ),
-              Container(
-                width: 60,
-                height: 60,
-                alignment: Alignment.topCenter,
-                decoration: const BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.all(Radius.circular(15)),
-                ),
-              ),
-              const Padding(padding: EdgeInsets.all(8)),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Container(
-                    width: 60,
-                    height: 8,
-                    color: Colors.white,
-                  ),
-                  Container(
-                    margin: const EdgeInsets.only(top: 4),
-                    width: 210,
-                    height: 18,
-                    color: Colors.white,
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-        itemCount: 6,
-      ),
-    ),
-  );
-}
+  return Builder(builder: (context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final baseColor = isDark ? Colors.grey[800]! : const Color(0xFFEBEBF4);
+    final highlightColor = isDark ? Colors.grey[700]! : const Color(0xFFF4F4F4);
 
-Widget changeIdentityShimmer() {
-  return Padding(
-    padding: const EdgeInsets.symmetric(horizontal: 15),
-    child: Shimmer(
-      gradient: const LinearGradient(
-        colors: [
-          Color(0xFFEBEBF4),
-          Color(0xFFF4F4F4),
-          Color(0xFFEBEBF4),
-        ],
-        stops: [
-          0.1,
-          0.3,
-          0.4,
-        ],
-        begin: Alignment(-1, -0.3),
-        end: Alignment(1, 0.3),
-      ),
-      child: ListView.builder(
-        padding: const EdgeInsets.symmetric(vertical: 15),
-        itemBuilder: (_, __) => Container(
-          padding: const EdgeInsets.only(bottom: 8, left: 8, right: 8, top: 8),
-          margin: const EdgeInsets.symmetric(vertical: 10, horizontal: 8),
-          decoration: BoxDecoration(
-            border: Border.all(color: Colors.white),
-            borderRadius: BorderRadius.circular(14),
-          ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const SizedBox(
-                height: 10,
-              ),
-              Container(
-                width: 60,
-                height: 60,
-                alignment: Alignment.topCenter,
-                decoration: const BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.all(Radius.circular(15)),
-                ),
-              ),
-              const Padding(padding: EdgeInsets.all(8)),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Container(
-                    width: 60,
-                    height: 8,
-                    color: Colors.white,
-                  ),
-                  Container(
-                    margin: const EdgeInsets.only(top: 4),
-                    width: 210,
-                    height: 18,
-                    color: Colors.white,
-                  ),
-                ],
-              ),
-            ],
-          ),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 15),
+      child: Shimmer(
+        gradient: LinearGradient(
+          colors: [
+            baseColor,
+            highlightColor,
+            baseColor,
+          ],
+          stops: const [
+            0.1,
+            0.3,
+            0.4,
+          ],
+          begin: const Alignment(-1, -0.3),
+          end: const Alignment(1, 0.3),
         ),
-        itemCount: 6,
-      ),
-    ),
-  );
-}
-
-Widget chatTabShimmer() {
-  return Shimmer(
-    gradient: const LinearGradient(
-      colors: [
-        Color(0xFFEBEBF4),
-        Color(0xFFF4F4F4),
-        Color(0xFFEBEBF4),
-      ],
-      stops: [
-        0.1,
-        0.3,
-        0.4,
-      ],
-      begin: Alignment(-1, -0.3),
-      end: Alignment(1, 0.3),
-    ),
-    child: ListView.builder(
-      padding: const EdgeInsets.symmetric(vertical: 15),
-      itemBuilder: (_, __) => Container(
-        padding: const EdgeInsets.only(bottom: 8, left: 8, right: 8, top: 8),
-        margin: const EdgeInsets.symmetric(vertical: 10, horizontal: 14),
-        decoration: BoxDecoration(
-          border: Border.all(color: Colors.white),
-          borderRadius: BorderRadius.circular(14),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const CircleAvatar(
-              backgroundColor: Colors.white,
-              radius: 20,
+        child: ListView.builder(
+          padding: const EdgeInsets.symmetric(vertical: 15),
+          itemBuilder: (_, __) => Container(
+            padding: const EdgeInsets.only(bottom: 8, left: 8, right: 8, top: 8),
+            margin: const EdgeInsets.only(top: 8, bottom: 10, left: 8, right: 8),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.white),
+              borderRadius: BorderRadius.circular(14),
             ),
-            const Padding(padding: EdgeInsets.all(8)),
-            Column(
+            child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Container(
-                  width: 60,
-                  height: 8,
-                  color: Colors.white,
+                const SizedBox(
+                  height: 10,
                 ),
                 Container(
-                  margin: const EdgeInsets.only(top: 4),
-                  width: 210,
-                  height: 18,
-                  color: Colors.white,
+                  width: 60,
+                  height: 60,
+                  alignment: Alignment.topCenter,
+                  decoration: const BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.all(Radius.circular(15)),
+                  ),
+                ),
+                const Padding(padding: EdgeInsets.all(8)),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      width: 60,
+                      height: 8,
+                      color: Colors.white,
+                    ),
+                    Container(
+                      margin: const EdgeInsets.only(top: 4),
+                      width: 210,
+                      height: 18,
+                      color: Colors.white,
+                    ),
+                  ],
                 ),
               ],
             ),
-          ],
+          ),
+          itemCount: 6,
         ),
       ),
-      itemCount: 5,
-    ),
-  );
+    );
+  });
+}
+
+Widget changeIdentityShimmer() {
+  return Builder(builder: (context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final baseColor = isDark ? Colors.grey[800]! : const Color(0xFFEBEBF4);
+    final highlightColor = isDark ? Colors.grey[700]! : const Color(0xFFF4F4F4);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 15),
+      child: Shimmer(
+        gradient: LinearGradient(
+          colors: [
+            baseColor,
+            highlightColor,
+            baseColor,
+          ],
+          stops: const [
+            0.1,
+            0.3,
+            0.4,
+          ],
+          begin: const Alignment(-1, -0.3),
+          end: const Alignment(1, 0.3),
+        ),
+        child: ListView.builder(
+          padding: const EdgeInsets.symmetric(vertical: 15),
+          itemBuilder: (_, __) => Container(
+            padding: const EdgeInsets.only(bottom: 8, left: 8, right: 8, top: 8),
+            margin: const EdgeInsets.symmetric(vertical: 10, horizontal: 8),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.white),
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(
+                  height: 10,
+                ),
+                Container(
+                  width: 60,
+                  height: 60,
+                  alignment: Alignment.topCenter,
+                  decoration: const BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.all(Radius.circular(15)),
+                  ),
+                ),
+                const Padding(padding: EdgeInsets.all(8)),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      width: 60,
+                      height: 8,
+                      color: Colors.white,
+                    ),
+                    Container(
+                      margin: const EdgeInsets.only(top: 4),
+                      width: 210,
+                      height: 18,
+                      color: Colors.white,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          itemCount: 6,
+        ),
+      ),
+    );
+  });
+}
+
+Widget chatTabShimmer() {
+  return Builder(builder: (context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final baseColor = isDark ? Colors.grey[800]! : const Color(0xFFEBEBF4);
+    final highlightColor = isDark ? Colors.grey[700]! : const Color(0xFFF4F4F4);
+
+    return Shimmer(
+      gradient: LinearGradient(
+        colors: [
+          baseColor,
+          highlightColor,
+          baseColor,
+        ],
+        stops: const [
+          0.1,
+          0.3,
+          0.4,
+        ],
+        begin: const Alignment(-1, -0.3),
+        end: const Alignment(1, 0.3),
+      ),
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(vertical: 15),
+        itemBuilder: (_, __) => Container(
+          padding: const EdgeInsets.only(bottom: 8, left: 8, right: 8, top: 8),
+          margin: const EdgeInsets.symmetric(vertical: 10, horizontal: 14),
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.white),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const CircleAvatar(
+                backgroundColor: Colors.white,
+                radius: 20,
+              ),
+              const Padding(padding: EdgeInsets.all(8)),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: 60,
+                    height: 8,
+                    color: Colors.white,
+                  ),
+                  Container(
+                    margin: const EdgeInsets.only(top: 4),
+                    width: 210,
+                    height: 18,
+                    color: Colors.white,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        itemCount: 5,
+      ),
+    );
+  });
 }

--- a/lib/common/sliver_persistent_header.dart
+++ b/lib/common/sliver_persistent_header.dart
@@ -12,7 +12,7 @@ SliverPersistentHeader sliverPersistentHeader(
       minHeight: 3 * personDelegateHeight / 4,
       maxHeight: 3 * personDelegateHeight / 4,
       child: Container(
-        color: Colors.white,
+        color: Theme.of(context).colorScheme.surface,
         padding: const EdgeInsets.only(left: personDelegateHeight / 4),
         alignment: Alignment.centerLeft,
         child: Text(
@@ -61,7 +61,7 @@ SliverPersistentHeader makeHeader(String headerText, BuildContext context) {
       minHeight: 30,
       maxHeight: 60,
       child: Container(
-        color: Theme.of(context).scaffoldBackgroundColor,
+        color: Theme.of(context).colorScheme.surface,
         padding: const EdgeInsets.symmetric(horizontal: 16),
         child: Align(
           alignment: Alignment.centerLeft,

--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+final lightTheme = ThemeData(
+  useMaterial3: true,
+  brightness: Brightness.light,
+  colorScheme: ColorScheme.fromSeed(
+    seedColor: const Color(0xFF29ABE2),
+    brightness: Brightness.light,
+    surface: Colors.white,
+  ),
+  fontFamily: 'Oxygen',
+  appBarTheme: const AppBarWidgetTheme(
+    backgroundColor: Colors.white,
+    foregroundColor: Colors.black,
+    elevation: 0,
+  ),
+);
+
+final darkTheme = ThemeData(
+  useMaterial3: true,
+  brightness: Brightness.dark,
+  colorScheme: ColorScheme.fromSeed(
+    seedColor: const Color(0xFF29ABE2),
+    brightness: Brightness.dark,
+    surface: const Color(0xFF121212),
+  ),
+  fontFamily: 'Oxygen',
+  appBarTheme: const AppBarWidgetTheme(
+    backgroundColor: Color(0xFF121212),
+    foregroundColor: Colors.white,
+    elevation: 0,
+  ),
+);
+
+// Helper for older versions of Flutter if needed, though project is on 3.27+
+typedef AppBarWidgetTheme = AppBarTheme;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,9 @@
+import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:oktoast/oktoast.dart';
 import 'package:provider/provider.dart';
 import 'package:retroshare/common/notifications.dart';
+import 'package:retroshare/common/theme_data.dart';
 import 'package:retroshare/model/app_life_cycle_state.dart';
 import 'package:retroshare/provider/auth.dart';
 import 'package:retroshare/provider/friend_location.dart';
@@ -12,12 +14,15 @@ import 'package:retroshare/routes.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  final savedThemeMode = await AdaptiveTheme.getThemeMode();
   //initializeNotifications();
-  runApp(const App());
+  runApp(App(savedThemeMode: savedThemeMode));
 }
 
 class App extends StatefulWidget {
-  const App({super.key});
+  const App({super.key, this.savedThemeMode});
+
+  final AdaptiveThemeMode? savedThemeMode;
 
   @override
   // ignore: unnecessary_new
@@ -60,17 +65,20 @@ class _AppState extends State<App> with WidgetsBindingObserver {
               roomChatLobby!..authToken = auth.authtoken!,
         ),
       ],
-      child: Builder(
-        builder: (context) {
-          return const OKToast(
-            child: MaterialApp(
-              debugShowCheckedModeBanner: false,
-              title: 'Retroshare',
-              initialRoute: '/',
-              onGenerateRoute: RouteGenerator.generateRoute,
-            ),
-          );
-        },
+      child: AdaptiveTheme(
+        light: lightTheme,
+        dark: darkTheme,
+        initial: widget.savedThemeMode ?? AdaptiveThemeMode.light,
+        builder: (theme, darkTheme) => OKToast(
+          child: MaterialApp(
+            debugShowCheckedModeBanner: false,
+            title: 'Retroshare',
+            theme: theme,
+            darkTheme: darkTheme,
+            initialRoute: '/',
+            onGenerateRoute: RouteGenerator.generateRoute,
+          ),
+        ),
       ),
     );
   }

--- a/lib/ui/about_screen.dart
+++ b/lib/ui/about_screen.dart
@@ -49,9 +49,9 @@ class AboutScreenState extends State<AboutScreen> {
         index: _stackToView,
         children: [
           WebViewWidget(controller: _controller),
-          const ColoredBox(
-            color: Colors.white,
-            child: Center(
+          ColoredBox(
+            color: Theme.of(context).colorScheme.surface,
+            child: const Center(
               child: CircularProgressIndicator(),
             ),
           ),

--- a/lib/ui/add_friend/add_friend_screen.dart
+++ b/lib/ui/add_friend/add_friend_screen.dart
@@ -16,7 +16,7 @@ class AddFriendScreenState extends State<AddFriendScreen> {
     return Scaffold(
       resizeToAvoidBottomInset: false,
       appBar: appBar('Add Friend', context),
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       body: const SafeArea(
         child: Padding(
           padding: EdgeInsets.symmetric(horizontal: 30, vertical: 10),

--- a/lib/ui/add_friend/add_friend_text.dart
+++ b/lib/ui/add_friend/add_friend_text.dart
@@ -102,7 +102,7 @@ class GetAddfriendState extends State<GetAddfriend> {
                   padding: const EdgeInsets.all(10),
                   child: const Text(
                     'Add Friend',
-                    style: TextStyle(fontSize: 13),
+                    style: TextStyle(fontSize: 13, color: Colors.white),
                     textAlign: TextAlign.center,
                   ),
                 ),
@@ -133,7 +133,7 @@ class GetAddfriendState extends State<GetAddfriend> {
                   padding: const EdgeInsets.all(10),
                   child: const Text(
                     'Add Friend via QR',
-                    style: TextStyle(fontSize: 13),
+                    style: TextStyle(fontSize: 13, color: Colors.white),
                     textAlign: TextAlign.center,
                   ),
                 ),

--- a/lib/ui/add_friend/add_friends_utils.dart
+++ b/lib/ui/add_friend/add_friends_utils.dart
@@ -124,7 +124,7 @@ class GetInviteState extends State<GetInvite> with TickerProviderStateMixin {
                 child: Container(
                   height: 150,
                   decoration: BoxDecoration(
-                    color: Colors.grey[200],
+                    color: Theme.of(context).colorScheme.surfaceContainerHighest,
                     borderRadius: BorderRadius.circular(6),
                   ),
                 ),
@@ -132,13 +132,13 @@ class GetInviteState extends State<GetInvite> with TickerProviderStateMixin {
               Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Icon(Icons.error, color: Colors.grey[600], size: 30),
+                  Icon(Icons.error, color: Theme.of(context).colorScheme.error, size: 30),
                   const SizedBox(height: 8),
-                  const Text(
+                  Text(
                     'Could not load invite',
                     style: TextStyle(
                       fontWeight: FontWeight.bold,
-                      color: Colors.grey,
+                      color: Theme.of(context).colorScheme.error,
                       fontFamily: 'Oxygen',
                     ),
                   ),
@@ -157,7 +157,7 @@ class GetInviteState extends State<GetInvite> with TickerProviderStateMixin {
                 child: Container(
                   height: 150,
                   decoration: BoxDecoration(
-                    color: Colors.grey[200],
+                    color: Theme.of(context).colorScheme.surfaceContainerHighest,
                     borderRadius: BorderRadius.circular(6),
                   ),
                 ),
@@ -171,7 +171,7 @@ class GetInviteState extends State<GetInvite> with TickerProviderStateMixin {
                     'Loading...',
                     style: TextStyle(
                       fontWeight: FontWeight.bold,
-                      color: Colors.blueAccent[100],
+                      color: Theme.of(context).colorScheme.primary,
                       fontFamily: 'Oxygen',
                     ),
                   ),
@@ -196,7 +196,7 @@ class GetInviteState extends State<GetInvite> with TickerProviderStateMixin {
                   minLines: 10,
                   style: GoogleFonts.oxygen(
                     textStyle:
-                        const TextStyle(fontSize: 12, color: Colors.black54),
+                        TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurfaceVariant),
                   ),
                   textAlign: TextAlign.center,
                   textAlignVertical: TextAlignVertical.center,
@@ -204,7 +204,7 @@ class GetInviteState extends State<GetInvite> with TickerProviderStateMixin {
                     contentPadding: const EdgeInsets.symmetric(
                         horizontal: 15, vertical: 10,),
                     filled: true,
-                    fillColor: Colors.black.withOpacity(.05),
+                    fillColor: Theme.of(context).colorScheme.surfaceContainerHighest,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(6),
                       borderSide: BorderSide.none,
@@ -226,7 +226,7 @@ class GetInviteState extends State<GetInvite> with TickerProviderStateMixin {
                     },
                     icon: Icon(
                       Icons.copy,
-                      color: Colors.blueAccent[200],
+                      color: Theme.of(context).colorScheme.primary,
                       size: 30,
                     ),
                     tooltip: 'Copy Invite',
@@ -238,7 +238,7 @@ class GetInviteState extends State<GetInvite> with TickerProviderStateMixin {
                       fontWeight: FontWeight.bold,
                       fontFamily: 'Oxygen',
                       fontSize: 12,
-                      color: Colors.blueAccent[100],
+                      color: Theme.of(context).colorScheme.primary.withOpacity(0.7),
                     ),
                   ),
                 ],
@@ -277,7 +277,7 @@ class GetInviteState extends State<GetInvite> with TickerProviderStateMixin {
             });
           },
           contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-          activeThumbColor: Colors.blueAccent,
+          activeThumbColor: Theme.of(context).colorScheme.primary,
         ),
         const SizedBox(height: 10),
       ],

--- a/lib/ui/change_identity_screen.dart
+++ b/lib/ui/change_identity_screen.dart
@@ -27,7 +27,7 @@ class ChangeIdentityScreenState extends State<ChangeIdentityScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: appBar('Change Identity', context),
       body: SafeArea(
         child: Padding(
@@ -96,7 +96,7 @@ class ChangeIdentityScreenState extends State<ChangeIdentityScreen> {
                     padding: const EdgeInsets.all(10),
                     child: Text(
                       'Change Identity',
-                      style: Theme.of(context).textTheme.labelLarge,
+                      style: Theme.of(context).textTheme.labelLarge?.copyWith(color: Colors.white),
                       textAlign: TextAlign.center,
                     ),
                   ),

--- a/lib/ui/create_identity/create_identity_screen.dart
+++ b/lib/ui/create_identity/create_identity_screen.dart
@@ -11,24 +11,29 @@ class CreateIdentityScreen extends StatefulWidget {
 
 class CreateIdentityScreenState extends State<CreateIdentityScreen>
     with SingleTickerProviderStateMixin {
-  late final Animation<Color?> _leftTabIconColor;
-  late final Animation<Color?> _rightTabIconColor;
+  late Animation<Color?> _leftTabIconColor;
+  late Animation<Color?> _rightTabIconColor;
   late final TabController _tabController;
   static const double _appBarHeight = kToolbarHeight;
   static const double _tabVerticalPadding = 20;
   static const double _tabBottomOffset = (_appBarHeight - 40) / 2;
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _leftTabIconColor =
+        ColorTween(begin: Theme.of(context).colorScheme.surfaceContainerHighest, end: Theme.of(context).colorScheme.primary)
+            .animate(_tabController.animation!);
+    _rightTabIconColor =
+        ColorTween(begin: Theme.of(context).colorScheme.primary, end: Theme.of(context).colorScheme.surfaceContainerHighest)
+            .animate(_tabController.animation!);
+  }
+
+  @override
   void initState() {
     super.initState();
     _tabController =
         TabController(vsync: this, length: widget.isFirstId ? 1 : 2);
-    _leftTabIconColor =
-        ColorTween(begin: const Color(0xFFF5F5F5), end: Colors.white)
-            .animate(_tabController.animation!);
-    _rightTabIconColor =
-        ColorTween(begin: Colors.white, end: const Color(0xFFF5F5F5))
-            .animate(_tabController.animation!);
   }
 
   @override
@@ -41,7 +46,7 @@ class CreateIdentityScreenState extends State<CreateIdentityScreen>
   Widget build(BuildContext context) {
     return Scaffold(
       resizeToAvoidBottomInset: false,
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
         title: const Text('Create Identity'),
       ),
@@ -135,7 +140,12 @@ class AnimatedTabIndicator extends StatelessWidget {
                 child: Text(
                   label,
                   overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.bodyMedium,
+                  style: TextStyle(
+                    color: animation.value == Theme.of(context).colorScheme.primary
+                        ? Theme.of(context).colorScheme.onPrimary
+                        : Theme.of(context).colorScheme.onSurfaceVariant,
+                    fontSize: 14,
+                  ),
                 ),
               ),
             ),

--- a/lib/ui/create_identity/generic_identity_tab.dart
+++ b/lib/ui/create_identity/generic_identity_tab.dart
@@ -132,17 +132,17 @@ class GenericIdentityTabState extends State<GenericIdentityTab> {
                                 : null,
                             shape: BoxShape.circle,
                             border: Border.all(
-                              color: Colors.grey[300]!,
+                              color: Theme.of(context).dividerColor,
                               width: 2,
                             ),
-                            color: Colors.grey[200],
+                            color: Theme.of(context).colorScheme.surfaceContainerHighest,
                           ),
                           child: (_image?.mData == null)
                               ? Center(
                                   child: Icon(
                                     Icons.person,
                                     size: 100,
-                                    color: Colors.grey[400],
+                                    color: Theme.of(context).hintColor,
                                   ),
                                 )
                               : null,

--- a/lib/ui/create_room_screen.dart
+++ b/lib/ui/create_room_screen.dart
@@ -210,11 +210,12 @@ class CreateRoomScreenState extends State<CreateRoomScreen>
         _onGoBack();
       },
       child: Scaffold(
+        backgroundColor: Theme.of(context).colorScheme.surface,
         body: SafeArea(
           child: Column(
             children: <Widget>[
               Container(
-                color: Colors.white,
+                color: Theme.of(context).colorScheme.surface,
                 padding: const EdgeInsets.symmetric(horizontal: 8),
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -261,8 +262,7 @@ class CreateRoomScreenState extends State<CreateRoomScreen>
                                                 decoration: BoxDecoration(
                                                   borderRadius:
                                                       BorderRadius.circular(15),
-                                                  color:
-                                                      const Color(0xFFF5F5F5),
+                                                  color: Theme.of(context).colorScheme.surfaceContainerHighest,
                                                 ),
                                                 padding:
                                                     const EdgeInsets.symmetric(
@@ -279,11 +279,12 @@ class CreateRoomScreenState extends State<CreateRoomScreen>
                                                           controller:
                                                               _roomNameController,
                                                           decoration:
-                                                              const InputDecoration(
+                                                              InputDecoration(
                                                             border: InputBorder
                                                                 .none,
                                                             hintText:
                                                                 'Room name',
+                                                            hintStyle: TextStyle(color: Theme.of(context).hintColor),
                                                           ),
                                                           style:
                                                               Theme.of(context)
@@ -306,8 +307,7 @@ class CreateRoomScreenState extends State<CreateRoomScreen>
                                                 decoration: BoxDecoration(
                                                   borderRadius:
                                                       BorderRadius.circular(15),
-                                                  color:
-                                                      const Color(0xFFF5F5F5),
+                                                  color: Theme.of(context).colorScheme.surfaceContainerHighest,
                                                 ),
                                                 padding:
                                                     const EdgeInsets.symmetric(
@@ -324,11 +324,12 @@ class CreateRoomScreenState extends State<CreateRoomScreen>
                                                           controller:
                                                               _roomTopicController,
                                                           decoration:
-                                                              const InputDecoration(
+                                                              InputDecoration(
                                                             border: InputBorder
                                                                 .none,
                                                             hintText:
                                                                 'Room topic',
+                                                            hintStyle: TextStyle(color: Theme.of(context).hintColor),
                                                           ),
                                                           style:
                                                               Theme.of(context)
@@ -504,8 +505,8 @@ class CreateRoomScreenState extends State<CreateRoomScreen>
                         left: 8,
                         right: 16,
                       ),
-                      decoration: const BoxDecoration(
-                        color: Colors.white,
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.surface,
                       ),
 //                      height: _buttonHeightAnimation.value,
                       child: FadeTransition(
@@ -568,7 +569,7 @@ class CreateRoomScreenState extends State<CreateRoomScreen>
                                   });
                                 },
                                 child: Container(
-                                  color: Colors.white,
+                                  color: Theme.of(context).colorScheme.surface,
                                   height: _buttonHeightAnimation.value,
                                   child: FadeTransition(
                                     opacity: _buttonFadeAnimation,

--- a/lib/ui/discover_chats_screen.dart
+++ b/lib/ui/discover_chats_screen.dart
@@ -43,7 +43,7 @@ class DiscoverChatsScreenState extends State<DiscoverChatsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       body: SafeArea(
         child: Column(
           children: <Widget>[

--- a/lib/ui/friends_locations_screen.dart
+++ b/lib/ui/friends_locations_screen.dart
@@ -32,7 +32,7 @@ class FriendsLocationsScreenState extends State<FriendsLocationsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: appBar('Friend Location', context),
       body: SafeArea(
         //top: true,

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -128,7 +128,7 @@ class HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
               child: Column(
                 children: [
                   AppBar(
-                    backgroundColor: Colors.white,
+                    backgroundColor: Theme.of(context).colorScheme.surface,
                     elevation: 2,
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(15),
@@ -143,9 +143,12 @@ class HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                       ),
                     ),
                     primary: false,
-                    title: const Text(
+                    title: Text(
                       'Search',
-                      style: TextStyle(color: Colors.grey, fontSize: 14),
+                      style: TextStyle(
+                        color: Theme.of(context).hintColor,
+                        fontSize: 14,
+                      ),
                       textAlign: TextAlign.start,
                     ),
                     actions: <Widget>[
@@ -251,16 +254,16 @@ class HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                         Icon(
                           Icons.chat_bubble_outline,
                           color: _tabController.index == 0
-                              ? Colors.blue
-                              : Colors.grey,
+                              ? Theme.of(context).colorScheme.primary
+                              : Theme.of(context).disabledColor,
                         ),
                         Text(
                           'Chats',
                           style: TextStyle(
                             fontSize: 10,
                             color: _tabController.index == 0
-                                ? Colors.blue
-                                : Colors.grey,
+                                ? Theme.of(context).colorScheme.primary
+                                : Theme.of(context).disabledColor,
                           ),
                         ),
                       ],
@@ -277,16 +280,16 @@ class HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                         Icon(
                           Icons.people_outline,
                           color: _tabController.index == 1
-                              ? Colors.blue
-                              : Colors.grey,
+                              ? Theme.of(context).colorScheme.primary
+                              : Theme.of(context).disabledColor,
                         ),
                         Text(
                           'Friends',
                           style: TextStyle(
                             fontSize: 10,
                             color: _tabController.index == 1
-                                ? Colors.blue
-                                : Colors.grey,
+                                ? Theme.of(context).colorScheme.primary
+                                : Theme.of(context).disabledColor,
                           ),
                         ),
                       ],

--- a/lib/ui/notification_screen.dart
+++ b/lib/ui/notification_screen.dart
@@ -33,7 +33,7 @@ class NotificationScreenState extends State<NotificationScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       body: SafeArea(
         child: Column(
           children: <Widget>[
@@ -103,26 +103,28 @@ class NotificationScreenState extends State<NotificationScreen> {
                                                 text: TextSpan(
                                                   text:
                                                       '${snapshot.data[index]['location'].accountName}',
-                                                  style: const TextStyle(
+                                                  style: TextStyle(
                                                     fontFamily: 'Oxygen',
                                                     fontSize: 16,
-                                                    color: Colors.black,
+                                                    color: Theme.of(context).colorScheme.onSurface,
                                                   ),
                                                   children: <TextSpan>[
-                                                    const TextSpan(
+                                                    TextSpan(
                                                       text:
                                                           ' sent you the invite to join the chatlobby ',
                                                       style: TextStyle(
                                                         fontSize: 15,
                                                         fontFamily: 'Oxygen',
+                                                        color: Theme.of(context).colorScheme.onSurface,
                                                       ),
                                                     ),
                                                     TextSpan(
                                                       text:
                                                           '${snapshot.data[index]['lobby_name']}.',
-                                                      style: const TextStyle(
+                                                      style: TextStyle(
                                                         fontSize: 15,
                                                         fontFamily: 'Oxygen',
+                                                        color: Theme.of(context).colorScheme.onSurface,
                                                       ),
                                                     ),
                                                   ],

--- a/lib/ui/profile_screen.dart
+++ b/lib/ui/profile_screen.dart
@@ -20,6 +20,7 @@ class ProfileScreenState extends State<ProfileScreen> {
     final lastAccount =
         Provider.of<AccountCredentials>(context, listen: false).loggedinAccount;
     return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: appBar('Identity Info', context),
       body: SingleChildScrollView(
         child: Column(
@@ -31,11 +32,11 @@ class ProfileScreenState extends State<ProfileScreen> {
               decoration: (widget.curr.avatar == null)
                   ? BoxDecoration(
                       borderRadius: BorderRadius.circular(10),
-                      border: Border.all(),
+                      border: Border.all(color: Theme.of(context).dividerColor),
                     )
                   : BoxDecoration(
                       borderRadius: BorderRadius.circular(10),
-                      border: Border.all(),
+                      border: Border.all(color: Theme.of(context).dividerColor),
                       image: DecorationImage(
                         fit: BoxFit.fill,
                         image: MemoryImage(base64.decode(widget.curr.avatar!)),
@@ -104,8 +105,11 @@ class ProfileScreenState extends State<ProfileScreen> {
                         ),
                         child: const Text(
                           'Edit Identity',
-                          style:
-                              TextStyle(fontSize: 15, fontFamily: 'Vollkorn'),
+                          style: TextStyle(
+                            fontSize: 15,
+                            fontFamily: 'Vollkorn',
+                            color: Colors.white,
+                          ),
                           textAlign: TextAlign.center,
                         ),
                       ),
@@ -122,37 +126,42 @@ class ProfileScreenState extends State<ProfileScreen> {
 }
 
 Widget textField(String text, String label) {
-  return Column(
-    crossAxisAlignment: CrossAxisAlignment.start,
-    mainAxisSize: MainAxisSize.min,
-    children: [
-      Text(
-        label,
-        style: const TextStyle(
-          fontFamily: 'Vollkorn',
-          fontSize: 16,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-      TextFormField(
-        readOnly: true,
-        initialValue: text,
-        style: const TextStyle(
-          fontSize: 12,
-          fontWeight: FontWeight.bold,
-          fontFamily: 'Oxygen',
-        ),
-        decoration: InputDecoration(
-          prefix: const SizedBox(
-            width: 10,
-          ),
-          labelStyle: const TextStyle(fontSize: 12),
-          border: OutlineInputBorder(
-            borderSide: const BorderSide(width: 2),
-            borderRadius: BorderRadius.circular(12),
+  return Builder(builder: (context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(
+            fontFamily: 'Vollkorn',
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
           ),
         ),
-      ),
-    ],
-  );
+        TextFormField(
+          readOnly: true,
+          initialValue: text,
+          style: const TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.bold,
+            fontFamily: 'Oxygen',
+          ),
+          decoration: InputDecoration(
+            prefix: const SizedBox(
+              width: 10,
+            ),
+            labelStyle: const TextStyle(fontSize: 12),
+            border: OutlineInputBorder(
+              borderSide: BorderSide(
+                width: 2,
+                color: Theme.of(context).dividerColor,
+              ),
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+        ),
+      ],
+    );
+  });
 }

--- a/lib/ui/room/room_friends_tab.dart
+++ b/lib/ui/room/room_friends_tab.dart
@@ -137,7 +137,7 @@ class RoomFriendsTabState extends State<RoomFriendsTab> {
                           onLongPress: (Offset tapPosition) {
                             showCustomMenu(
                               'Add to contacts',
-                              const Icon(Icons.add, color: Colors.black),
+                              Icon(Icons.add, color: Theme.of(context).colorScheme.onSurface),
                               () => _addToContacts(participant.mId),
                               tapPosition,
                               context,

--- a/lib/ui/room/room_screen.dart
+++ b/lib/ui/room/room_screen.dart
@@ -19,16 +19,20 @@ class RoomScreen extends StatefulWidget {
 class RoomScreenState extends State<RoomScreen>
     with SingleTickerProviderStateMixin {
   late final TabController _tabController;
-  late final Animation<Color?> _iconAnimation;
+  late Animation<Color?> _iconAnimation;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _iconAnimation =
+        ColorTween(begin: Theme.of(context).colorScheme.onSurface, end: Theme.of(context).colorScheme.primary)
+            .animate(_tabController.animation!);
+  }
 
   @override
   void initState() {
     super.initState();
     _tabController = TabController(vsync: this, length: widget.isRoom ? 2 : 1);
-
-    _iconAnimation =
-        ColorTween(begin: Colors.black, end: Colors.lightBlueAccent)
-            .animate(_tabController.animation!);
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (widget.chat.chatId == null) {
@@ -119,13 +123,13 @@ class RoomScreenState extends State<RoomScreen>
                       height: appBarHeight,
                       child: CircleAvatar(
                         radius: appBarHeight * 0.35,
-                        backgroundColor: Colors.grey[300],
+                        backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
                         backgroundImage: avatarImage,
                         child: !hasAvatar
                             ? Icon(
                                 Icons.person,
                                 size: appBarHeight * 0.4,
-                                color: Colors.grey[600],
+                                color: Theme.of(context).hintColor,
                               )
                             : null,
                       ),

--- a/lib/ui/search_screen.dart
+++ b/lib/ui/search_screen.dart
@@ -60,17 +60,11 @@ class SearchScreenState extends State<SearchScreen>
         }
       }
     });
-
-    _leftTabIconColor =
-        ColorTween(begin: const Color(0xFFF5F5F5), end: Colors.white)
-            .animate(_tabController.animation!);
-    _rightTabIconColor =
-        ColorTween(begin: Colors.white, end: const Color(0xFFF5F5F5))
-            .animate(_tabController.animation!);
   }
 
   @override
   void didChangeDependencies() {
+    super.didChangeDependencies();
     if (_init) {
       final friendIdentity = Provider.of<RoomChatLobby>(context, listen: false);
       final chatLobby = Provider.of<ChatLobby>(context, listen: false);
@@ -84,7 +78,13 @@ class SearchScreenState extends State<SearchScreen>
       publicChats = chatLobby.unSubscribedlist;
     }
     _init = false;
-    super.didChangeDependencies();
+
+    _leftTabIconColor =
+        ColorTween(begin: Theme.of(context).colorScheme.surfaceContainerHighest, end: Theme.of(context).colorScheme.primary)
+            .animate(_tabController.animation!);
+    _rightTabIconColor =
+        ColorTween(begin: Theme.of(context).colorScheme.primary, end: Theme.of(context).colorScheme.surfaceContainerHighest)
+            .animate(_tabController.animation!);
   }
 
   Future<void> _goToChat(Chat lobby) async {
@@ -115,7 +115,7 @@ class SearchScreenState extends State<SearchScreen>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       body: SafeArea(
         child: Column(
           children: <Widget>[
@@ -139,11 +139,11 @@ class SearchScreenState extends State<SearchScreen>
                   ),
                   Expanded(
                     child: Material(
-                      color: Colors.white,
+                      color: Colors.transparent,
                       child: Container(
                         decoration: BoxDecoration(
                           borderRadius: BorderRadius.circular(15),
-                          color: const Color(0xFFF5F5F5),
+                          color: Theme.of(context).colorScheme.surfaceContainerHighest,
                         ),
                         padding: const EdgeInsets.symmetric(horizontal: 15),
                         margin: const EdgeInsets.symmetric(horizontal: 8),
@@ -154,10 +154,7 @@ class SearchScreenState extends State<SearchScreen>
                             children: <Widget>[
                               Icon(
                                 Icons.search,
-                                color: Theme.of(context)
-                                    .textTheme
-                                    .bodyLarge
-                                    ?.color,
+                                color: Theme.of(context).hintColor,
                               ),
                               const SizedBox(
                                 width: 8,
@@ -166,9 +163,10 @@ class SearchScreenState extends State<SearchScreen>
                                 child: TextField(
                                   controller: _searchBoxFilter,
                                   autofocus: true,
-                                  decoration: const InputDecoration(
+                                  decoration: InputDecoration(
                                     border: InputBorder.none,
                                     hintText: 'Type text...',
+                                    hintStyle: TextStyle(color: Theme.of(context).hintColor),
                                   ),
                                   style: Theme.of(context).textTheme.bodyLarge,
                                 ),
@@ -209,7 +207,12 @@ class SearchScreenState extends State<SearchScreen>
                             child: Center(
                               child: Text(
                                 'Chats',
-                                style: Theme.of(context).textTheme.bodyLarge,
+                                style: TextStyle(
+                                  color: _tabController.index == 0
+                                      ? Theme.of(context).colorScheme.onPrimary
+                                      : Theme.of(context).colorScheme.onSurfaceVariant,
+                                  fontWeight: FontWeight.bold,
+                                ),
                               ),
                             ),
                           ),
@@ -239,7 +242,12 @@ class SearchScreenState extends State<SearchScreen>
                             child: Center(
                               child: Text(
                                 'People',
-                                style: Theme.of(context).textTheme.bodyLarge,
+                                style: TextStyle(
+                                  color: _tabController.index == 1
+                                      ? Theme.of(context).colorScheme.onPrimary
+                                      : Theme.of(context).colorScheme.onSurfaceVariant,
+                                  fontWeight: FontWeight.bold,
+                                ),
                               ),
                             ),
                           ),

--- a/lib/ui/signin_screen.dart
+++ b/lib/ui/signin_screen.dart
@@ -180,7 +180,7 @@ class SignInScreenState extends State<SignInScreen> {
       child: Container(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(15),
-          color: const Color(0xFFF5F5F5),
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
         ),
         padding: const EdgeInsets.symmetric(horizontal: 15),
         height: 40,
@@ -188,9 +188,9 @@ class SignInScreenState extends State<SignInScreen> {
           onLongPress: _revealLocations,
           child: Row(
             children: <Widget>[
-              const Icon(
+              Icon(
                 Icons.person_outline,
-                color: Color(0xFF9E9E9E),
+                color: Theme.of(context).hintColor,
                 size: 22,
               ),
               const SizedBox(width: 15),
@@ -229,17 +229,17 @@ class SignInScreenState extends State<SignInScreen> {
       child: Container(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(15),
-          color: const Color(0xFFF5F5F5),
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
         ),
         padding: const EdgeInsets.symmetric(horizontal: 15),
         height: 40,
         child: TextField(
           controller: passwordController,
-          decoration: const InputDecoration(
+          decoration: InputDecoration(
             border: InputBorder.none,
             icon: Icon(
               Icons.lock_outline,
-              color: Color(0xFF9E9E9E),
+              color: Theme.of(context).hintColor,
               size: 22,
             ),
             hintText: 'Password',
@@ -358,7 +358,7 @@ class SignInScreenState extends State<SignInScreen> {
     }
 
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       body: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints viewportConstraints) {
           return SingleChildScrollView(

--- a/lib/ui/signup_screen.dart
+++ b/lib/ui/signup_screen.dart
@@ -133,7 +133,7 @@ class SignUpScreenState extends State<SignUpScreen> {
       child: Container(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(15),
-          color: const Color(0xFFF5F5F5),
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
         ),
         padding: const EdgeInsets.symmetric(horizontal: 15),
         height: 40,
@@ -143,7 +143,7 @@ class SignUpScreenState extends State<SignUpScreen> {
             border: InputBorder.none,
             icon: Icon(
               icon,
-              color: const Color(0xFF9E9E9E),
+              color: Theme.of(context).hintColor,
               size: 22,
             ),
             hintText: hintText,
@@ -338,7 +338,7 @@ class SignUpScreenState extends State<SignUpScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       body: Center(
         child: SingleChildScrollView(
           child: SizedBox(

--- a/lib/ui/splash_screen.dart
+++ b/lib/ui/splash_screen.dart
@@ -157,6 +157,7 @@ class SplashState extends State<SplashScreen> {
     return PopScope(
       canPop: false,
       child: Scaffold(
+        backgroundColor: Theme.of(context).colorScheme.surface,
         body: Center(
           child: SingleChildScrollView(
             child: Column(

--- a/lib/ui/update_identity_screen.dart
+++ b/lib/ui/update_identity_screen.dart
@@ -99,7 +99,7 @@ class UpdateIdentityScreenState extends State<UpdateIdentityScreen> {
     }
 
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       body: SafeArea(
         child: Column(
           children: <Widget>[
@@ -220,7 +220,7 @@ class UpdateIdentityScreenState extends State<UpdateIdentityScreen> {
                                   child: Container(
                                     decoration: BoxDecoration(
                                       borderRadius: BorderRadius.circular(15),
-                                      color: const Color(0xFFF5F5F5),
+                                      color: Theme.of(context).colorScheme.surfaceContainerHighest,
                                     ),
                                     padding: const EdgeInsets.symmetric(
                                       horizontal: 15,
@@ -234,11 +234,11 @@ class UpdateIdentityScreenState extends State<UpdateIdentityScreen> {
                                           _showError = !_validate(text);
                                         });
                                       },
-                                      decoration: const InputDecoration(
+                                      decoration: InputDecoration(
                                         border: InputBorder.none,
                                         icon: Icon(
                                           Icons.person_outline,
-                                          color: Color(0xFF9E9E9E),
+                                          color: Theme.of(context).hintColor,
                                           size: 22,
                                         ),
                                         hintText: 'Name',
@@ -323,7 +323,7 @@ class UpdateIdentityScreenState extends State<UpdateIdentityScreen> {
                             padding: const EdgeInsets.all(10),
                             child: Text(
                               'Update Identity',
-                              style: Theme.of(context).textTheme.labelLarge,
+                              style: Theme.of(context).textTheme.labelLarge?.copyWith(color: Colors.white),
                               textAlign: TextAlign.center,
                             ),
                           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
 
   # Used to render chat messages
   flutter_html: 3.0.0
+  adaptive_theme: ^3.7.0
   simple_chips_input: ^1.2.1
   # For notifications
   flutter_local_notifications: ^19.1.0


### PR DESCRIPTION
I have successfully implemented dark mode in Retroshare-mobile using the adaptive_theme package.
Key Changes:

1. Added Dependencies: Added adaptive_theme to pubspec.yaml.
2. Theme Definitions: Created lib/common/theme_data.dart which defines a modern Material 3 lightTheme and darkTheme based on the Retroshare brand color (0xFF29ABE2).
3. Adaptive Setup: Modified lib/main.dart to wrap the app in AdaptiveTheme, which automatically saves and restores the user's theme preference.
4. Theme Switcher: Added a new menu item to the side drawer (lib/common/drawer.dart) that allows users to toggle between Light and Dark modes.
5. Global UI Updates: Systematically updated hardcoded colors across the following screens to ensure they automatically adapt to the current theme:
◦ HomeScreen (Bottom navigation and Search bar)
◦ SignIn & SignUp screens (Backgrounds and Input fields)
◦ CreateIdentity & ChangeIdentity screens
◦ Profile & Notification screens
◦ Room & Messages components
◦ About & Add Friend screens

6. Component Styling: Updated common components like BottomBar, Button, PersonDelegate, and Shimmer effects to use theme-based colors instead of fixed whites and grays.
The app will now respect the system theme by default, and users can manually toggle their preference from the drawer. The dark mode features a deep neutral background (#121212) for better readability and reduced eye strain.

code by gemini